### PR TITLE
Record Apps Script production release

### DIFF
--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -7,8 +7,13 @@ test installation, screenshots, and submission require the publisher account.
 ## Current release gate
 
 - Runtime version: `1.2.0`
+- Production Apps Script ID:
+  `1rlVWvciYu-wzqnY009I3oW-08ZPazYK1snrrMg9NNY7c5WBSkUK8W2Hb`
+- Current immutable Apps Script version: `2`
+- GitHub production release workflow:
+  `https://github.com/OilpriceAPI/google-sheets-addin/actions/workflows/apps-script-release.yml`
 - Marketplace status: publication pending
-- Local runtime/deployment/asset checks: automated by `npm run validate`
+- Runtime push/version and local deployment checks: complete
 - Required before submission: real Editor add-on test receipt and at least one
   real 1280x800 screenshot
 

--- a/TEST_RESULTS.md
+++ b/TEST_RESULTS.md
@@ -74,13 +74,31 @@ script passes the key to `curl` through standard input and never prints it.
 
 ## Account-bound release gates
 
-These cannot be proven from the source checkout and remain required:
+Completed on 2026-07-24:
 
-- push to the publisher-owned standalone Apps Script project;
+- created the publisher-owned standalone Apps Script project
+  `OilPriceAPI for Sheets`;
+- pushed exactly `Code.gs`, `Sidebar.html`, `FetchDialog.html`, and
+  `appsscript.json`;
+- created immutable Apps Script versions `1` and `2`;
+- configured the `apps-script-production` GitHub environment for `main` only;
+- stored clasp credentials as environment secrets;
+- ran the production release workflow successfully:
+  `https://github.com/OilpriceAPI/google-sheets-addin/actions/runs/30116108120`.
+
+Production release target:
+
+- Script ID:
+  `1rlVWvciYu-wzqnY009I3oW-08ZPazYK1snrrMg9NNY7c5WBSkUK8W2Hb`
+- Current immutable version: `2`
+- Apps Script editor:
+  `https://script.google.com/d/1rlVWvciYu-wzqnY009I3oW-08ZPazYK1snrrMg9NNY7c5WBSkUK8W2Hb/edit`
+
+Remaining Google account/Marketplace gates:
+
 - link that script to the standard Google Cloud project;
 - install and smoke the Editor add-on test deployment in a clean Sheet;
 - capture at least one real 1280x800 screenshot;
-- create the immutable Apps Script version;
 - configure OAuth and Marketplace SDK with the Script ID and version;
 - complete any required OAuth verification and submit the public listing.
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "clasp:login": "clasp login",
     "clasp:configure": "node scripts/configure-clasp.js",
     "clasp:status": "clasp status",
-    "deploy:push": "npm run validate && clasp push",
+    "deploy:push": "npm run validate && clasp push --force",
     "deploy:version": "clasp version",
     "deploy:list": "clasp deployments"
   },


### PR DESCRIPTION
## Summary
- record the production Apps Script ID and immutable version 2
- record successful protected-environment release automation
- make local deploy:push force the reviewed four-file bundle, matching CI
- narrow the remaining gates to Google Cloud, test deployment, screenshots, and Marketplace review

## Verification
- npm run validate: 26/26 pass
- npm audit --omit=dev: 0 vulnerabilities