### PR TITLE
fix: make Sheets formulas use spreadsheet-scoped credentials

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -142,7 +142,22 @@ function showAbout() {
   );
 }
 
+function getDocumentProperties_() {
+  try {
+    return PropertiesService.getDocumentProperties();
+  } catch (error) {
+    return null;
+  }
+}
+
 function getApiKey_() {
+  const documentProperties = getDocumentProperties_();
+  const documentKey = documentProperties
+    ? documentProperties.getProperty(KEY_PROPERTY)
+    : null;
+  if (documentKey) return documentKey;
+
+  // Migration fallback for keys saved by releases before Apps Script version 6.
   return PropertiesService.getUserProperties().getProperty(KEY_PROPERTY);
 }
 
@@ -158,13 +173,26 @@ function saveApiKey(apiKey) {
   if (typeof apiKey !== 'string' || !apiKey.trim()) {
     throw new Error('API key is required.');
   }
-  PropertiesService.getUserProperties().setProperty(KEY_PROPERTY, apiKey.trim());
-  return { success: true, message: 'API key saved in your Apps Script user properties.' };
+  const documentProperties = getDocumentProperties_();
+  if (!documentProperties) {
+    throw makeError_(
+      'ADDON_CONTEXT_REQUIRED',
+      'Open the OilPriceAPI sidebar from a Google Sheet before saving the API key.'
+    );
+  }
+  documentProperties.setProperty(KEY_PROPERTY, apiKey.trim());
+  PropertiesService.getUserProperties().deleteProperty(KEY_PROPERTY);
+  return {
+    success: true,
+    message: 'API key saved for this spreadsheet in Apps Script document properties.'
+  };
 }
 
 function deleteApiKey() {
+  const documentProperties = getDocumentProperties_();
+  if (documentProperties) documentProperties.deleteProperty(KEY_PROPERTY);
   PropertiesService.getUserProperties().deleteProperty(KEY_PROPERTY);
-  return { success: true, message: 'Stored API key deleted.' };
+  return { success: true, message: 'Stored spreadsheet API key deleted.' };
 }
 
 function getApiKeyStatus() {
@@ -231,7 +259,8 @@ function persistDiagnostic_(input) {
     if (typeof input.requestId === 'string' && input.requestId) {
       diagnostic.requestId = input.requestId.slice(0, 128);
     }
-    PropertiesService.getUserProperties().setProperty(
+    const properties = getDocumentProperties_() || PropertiesService.getUserProperties();
+    properties.setProperty(
       LAST_DIAGNOSTIC_PROPERTY,
       JSON.stringify(diagnostic)
     );
@@ -241,7 +270,8 @@ function persistDiagnostic_(input) {
 }
 
 function getLastDiagnostic() {
-  const raw = PropertiesService.getUserProperties().getProperty(LAST_DIAGNOSTIC_PROPERTY);
+  const properties = getDocumentProperties_() || PropertiesService.getUserProperties();
+  const raw = properties.getProperty(LAST_DIAGNOSTIC_PROPERTY);
   if (!raw) return null;
   try {
     const value = JSON.parse(raw);

--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -9,7 +9,7 @@ test installation, screenshots, and submission require the publisher account.
 - Runtime version: `1.2.0`
 - Production Apps Script ID:
   `1rlVWvciYu-wzqnY009I3oW-08ZPazYK1snrrMg9NNY7c5WBSkUK8W2Hb`
-- Current immutable Apps Script version: `2`
+- Current immutable Apps Script version: `7`
 - GitHub production release workflow:
   `https://github.com/OilpriceAPI/google-sheets-addin/actions/workflows/apps-script-release.yml`
 - Marketplace status: publication pending
@@ -95,6 +95,7 @@ In the linked standard Cloud project:
 ```text
 https://www.googleapis.com/auth/spreadsheets.currentonly
 https://www.googleapis.com/auth/script.external_request
+https://www.googleapis.com/auth/script.container.ui
 ```
 
 The manifest, OAuth consent screen, and Marketplace SDK scope lists must match.
@@ -131,6 +132,9 @@ Run this checklist:
 - [ ] The add-on appears under Extensions and opens the OilPriceAPI sidebar.
 - [ ] The sidebar initially reports no stored key.
 - [ ] Saving a key clears the input and never displays the stored value.
+- [ ] The saved key is scoped to the current spreadsheet through Apps Script
+      document properties; an editor can use formulas but cannot read the key
+      through the sidebar.
 - [ ] Test connection validates both HTTP status and the response schema.
 - [ ] `=OILPRICE_PRICE("WTI_USD")` returns a finite number.
 - [ ] `=OILPRICE_UNIT("WTI_USD")` returns a currency/unit value.
@@ -203,7 +207,7 @@ In the same standard Cloud project:
 3. Add an **Editor add-on** integration for Google Sheets.
 4. Enter the Apps Script project Script ID and the tested version number.
 5. Enable individual installation and, if desired, administrator installation.
-6. Enter the same two OAuth scopes used by the manifest and OAuth consent
+6. Enter the same three OAuth scopes used by the manifest and OAuth consent
    screen.
 7. Choose visibility deliberately:
    - Public: any Marketplace user after Google review.

--- a/MARKETPLACE_LISTING.md
+++ b/MARKETPLACE_LISTING.md
@@ -33,10 +33,12 @@ Detailed description:
 > Dataset access, history, and freshness depend on the configured API key,
 > source, and account entitlement.
 >
-> The API key is stored in per-user Apps Script properties. It is not written
-> to spreadsheet cells, URLs, diagnostics, or browser-side HTML. Generic GET
-> requests are restricted to a reviewed endpoint catalog and reject
-> credential-shaped query parameters.
+> The API key is stored in Apps Script document properties scoped to the
+> current spreadsheet so its formulas can retrieve data. It is not written to
+> spreadsheet cells, URLs, diagnostics, or browser-side HTML. Spreadsheet
+> editors can cause installed add-on formulas to make requests using the
+> configured key. Generic GET requests are restricted to a reviewed endpoint
+> catalog and reject credential-shaped query parameters.
 
 ## Support links
 
@@ -49,13 +51,14 @@ Detailed description:
 
 ## OAuth scopes and justification
 
-Use the same two scopes in the Apps Script manifest, OAuth consent screen, and
+Use the same three scopes in the Apps Script manifest, OAuth consent screen, and
 Marketplace SDK:
 
 | Scope | Justification |
 | --- | --- |
 | `https://www.googleapis.com/auth/spreadsheets.currentonly` | Read and write only the spreadsheet where the user runs the add-on, including inserting formulas and writing requested data tables. |
 | `https://www.googleapis.com/auth/script.external_request` | Send authenticated HTTPS GET requests to `api.oilpriceapi.com` for data explicitly requested by the user. |
+| `https://www.googleapis.com/auth/script.container.ui` | Display the add-on menu, API-key sidebar, help alerts, and data-fetch dialog inside the spreadsheet where the user runs the add-on. |
 
 The add-on does not request Drive-wide access, email, profile, or user-info
 scopes.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ The original `OILPRICE(code)` formula remains supported for existing sheets.
 
 ## Runtime and security contract
 
-- API keys are stored in per-user Apps Script properties.
+- API keys are stored in Apps Script document properties scoped to the current
+  spreadsheet so custom formulas can use them. Editors of that spreadsheet can
+  cause add-on formulas to make requests with the configured key.
 - The sidebar receives only configured/not-configured state; it never reads the
   stored key into browser-side HTML.
 - Generic GET calls are restricted to the same reviewed endpoint catalog as
@@ -61,8 +63,8 @@ The original `OILPRICE(code)` formula remains supported for existing sheets.
   responses fail with worksheet-readable recovery text.
 - Latest-request diagnostics contain endpoint path, status, duration,
   timestamp, and optional request ID—never the API key or query string.
-- The manifest requests only current-sheet and external-request scopes and
-  restricts URL fetches to `api.oilpriceapi.com`.
+- The manifest requests only current-sheet, external-request, and container-UI
+  scopes and restricts URL fetches to `api.oilpriceapi.com`.
 
 ## Validate locally
 

--- a/Sidebar.html
+++ b/Sidebar.html
@@ -251,7 +251,7 @@
         google.script.run
           .withSuccessHandler(function (result) {
             document.getElementById("keyState").textContent = result.configured
-              ? "A key is stored in your user properties."
+              ? "A key is stored for this spreadsheet."
               : "No key is stored.";
             if (result.configured) loadUserInfo();
           })

--- a/TEST_RESULTS.md
+++ b/TEST_RESULTS.md
@@ -1,6 +1,24 @@
 # Verification Results
 
-Verification date: 2026-07-24
+Verification date: 2026-07-25
+
+## Apps Script scope correction
+
+The sidebar and dialog smoke test exposed a release-manifest mismatch: the
+runtime calls `SpreadsheetApp.getUi().showSidebar(...)` and
+`showModalDialog(...)`, but immutable versions `2`, `3`, and `4` declared only
+the spreadsheet and external-request scopes.
+
+Direct `clasp` inspection on 2026-07-25 confirmed:
+
+- versions `2`, `3`, and `4` contain two OAuth scopes and must not be submitted;
+- versions `5` and `6` add
+  `https://www.googleapis.com/auth/script.container.ui`, but still resolve
+  formula credentials through the spreadsheet owner's user properties;
+- version `7` stores the credential in Apps Script document properties scoped
+  to the spreadsheet, with a legacy user-property migration fallback;
+- version `7` contains the same `Code`, `Sidebar`, `FetchDialog`, and manifest
+  source as the reviewed local runtime.
 
 ## Automated release validation
 
@@ -12,7 +30,7 @@ npm run validate
 
 Result:
 
-- 26 runtime/public-claims tests passed, 0 failed.
+- 28 runtime/public-claims tests passed, 0 failed.
 - Apps Script syntax, required functions, UI bindings, scopes, and fetch
   allowlist are valid.
 - The deployment package exposes only `Code.gs`, `Sidebar.html`,
@@ -24,7 +42,8 @@ Result:
 
 Covered behavior includes:
 
-- credential save, status, and deletion without returning the stored value;
+- spreadsheet-scoped credential save, legacy user-property migration, status,
+  and deletion without returning the stored value;
 - missing/invalid key, locked dataset, rate limit, timeout, and server recovery;
 - malformed JSON, empty success, and schema-drift rejection;
 - stable worksheet error codes, including API invalid-code suggestions;
@@ -80,7 +99,7 @@ Completed on 2026-07-24:
   `OilPriceAPI for Sheets`;
 - pushed exactly `Code.gs`, `Sidebar.html`, `FetchDialog.html`, and
   `appsscript.json`;
-- created immutable Apps Script versions `1` and `2`;
+- created immutable Apps Script versions `1` through `7`;
 - configured the `apps-script-production` GitHub environment for `main` only;
 - stored clasp credentials as environment secrets;
 - ran the production release workflow successfully:
@@ -90,7 +109,7 @@ Production release target:
 
 - Script ID:
   `1rlVWvciYu-wzqnY009I3oW-08ZPazYK1snrrMg9NNY7c5WBSkUK8W2Hb`
-- Current immutable version: `2`
+- Current immutable version: `7`
 - Apps Script editor:
   `https://script.google.com/d/1rlVWvciYu-wzqnY009I3oW-08ZPazYK1snrrMg9NNY7c5WBSkUK8W2Hb/edit`
 

--- a/WEEKEND_ACTION.md
+++ b/WEEKEND_ACTION.md
@@ -13,7 +13,7 @@ The standalone repository and Apps Script release are already deployed. Use:
   `https://script.google.com/d/1rlVWvciYu-wzqnY009I3oW-08ZPazYK1snrrMg9NNY7c5WBSkUK8W2Hb/edit`
 - Script ID:
   `1rlVWvciYu-wzqnY009I3oW-08ZPazYK1snrrMg9NNY7c5WBSkUK8W2Hb`
-- Immutable Apps Script version: `2`
+- Immutable Apps Script version: `7`
 - GitHub release:
   `https://github.com/OilpriceAPI/google-sheets-addin/releases/tag/v1.2.0`
 - Full operator runbook: `DEPLOYMENT_GUIDE.md`
@@ -45,9 +45,9 @@ linked above is the reviewed production target.
       and
       `https://www.oilpriceapi.com/terms/google-sheets-addon`.
 - [ ] Declare exactly these scopes:
-      `https://www.googleapis.com/auth/spreadsheets.currentonly`
-      and
-      `https://www.googleapis.com/auth/script.external_request`.
+      `https://www.googleapis.com/auth/spreadsheets.currentonly`,
+      `https://www.googleapis.com/auth/script.external_request`, and
+      `https://www.googleapis.com/auth/script.container.ui`.
 - [ ] Add the publisher and clean smoke-test accounts as test users while OAuth
       remains in Testing status.
 
@@ -90,8 +90,8 @@ Do not add Drive-wide, email, profile, or `userinfo.email` scopes.
 
 - [ ] In Google Workspace Marketplace SDK, add an **Editor add-on** integration
       for Google Sheets.
-- [ ] Enter the Script ID above and immutable version `2`.
-- [ ] Enter the same two OAuth scopes.
+- [ ] Enter the Script ID above and immutable version `7`.
+- [ ] Enter the same three OAuth scopes.
 - [ ] Choose **Public** visibility before saving. Google treats this choice as
       permanent; do not use Private as temporary staging.
 - [ ] Upload:
@@ -108,9 +108,14 @@ Do not add Drive-wide, email, profile, or `userinfo.email` scopes.
 - [ ] The Marketplace console shows a submitted/review state.
 - [ ] The submission confirmation or receipt is saved.
 - [ ] The exact submitted Script ID and version are recorded as:
-      `1rlVWvciYu-wzqnY009I3oW-08ZPazYK1snrrMg9NNY7c5WBSkUK8W2Hb`, version `2`.
+      `1rlVWvciYu-wzqnY009I3oW-08ZPazYK1snrrMg9NNY7c5WBSkUK8W2Hb`, version `7`.
 - [ ] No public page claims Marketplace availability before Google approves the
       listing.
 - [ ] After approval, a separate clean account installs the public listing and
       repeats the customer-critical smoke test before marketing copy changes.
 
+Versions `2`, `3`, and `4` do not include the required
+`script.container.ui` scope. Versions `5` and `6` still read formula
+credentials from the spreadsheet owner's user properties instead of the
+spreadsheet-scoped credential. Do not submit or restore versions `2` through
+`6`.

--- a/appsscript.json
+++ b/appsscript.json
@@ -5,7 +5,8 @@
   "runtimeVersion": "V8",
   "oauthScopes": [
     "https://www.googleapis.com/auth/spreadsheets.currentonly",
-    "https://www.googleapis.com/auth/script.external_request"
+    "https://www.googleapis.com/auth/script.external_request",
+    "https://www.googleapis.com/auth/script.container.ui"
   ],
   "urlFetchWhitelist": [
     "https://api.oilpriceapi.com/"

--- a/scripts/verify-deploy-package.js
+++ b/scripts/verify-deploy-package.js
@@ -40,6 +40,7 @@ const manifest = JSON.parse(
 assert.deepEqual(manifest.oauthScopes, [
   "https://www.googleapis.com/auth/spreadsheets.currentonly",
   "https://www.googleapis.com/auth/script.external_request",
+  "https://www.googleapis.com/auth/script.container.ui",
 ]);
 assert.deepEqual(manifest.urlFetchWhitelist, [
   "https://api.oilpriceapi.com/",

--- a/test/live-smoke.js
+++ b/test/live-smoke.js
@@ -60,8 +60,13 @@ const context = {
   Math,
   Number,
   PropertiesService: {
-    getUserProperties: () => ({
+    getDocumentProperties: () => ({
       getProperty: () => apiKey,
+      setProperty: () => undefined,
+      deleteProperty: () => undefined,
+    }),
+    getUserProperties: () => ({
+      getProperty: () => null,
       setProperty: () => undefined,
       deleteProperty: () => undefined,
     }),

--- a/test/runtime.test.js
+++ b/test/runtime.test.js
@@ -26,16 +26,19 @@ function historyBody(records) {
 }
 
 function createHarness() {
-  const properties = new Map();
+  const documentPropertyValues = new Map();
+  const userPropertyValues = new Map();
   const cache = new Map();
   const responses = [];
   const requests = [];
 
-  const userProperties = {
-    getProperty: (key) => properties.get(key) || null,
-    setProperty: (key, value) => properties.set(key, value),
-    deleteProperty: (key) => properties.delete(key),
-  };
+  const propertyStore = (values) => ({
+    getProperty: (key) => values.get(key) || null,
+    setProperty: (key, value) => values.set(key, value),
+    deleteProperty: (key) => values.delete(key),
+  });
+  const documentProperties = propertyStore(documentPropertyValues);
+  const userProperties = propertyStore(userPropertyValues);
   const userCache = {
     get: (key) => cache.get(key) || null,
     put: (key, value) => cache.set(key, value),
@@ -49,7 +52,10 @@ function createHarness() {
     JSON,
     Math,
     Number,
-    PropertiesService: { getUserProperties: () => userProperties },
+    PropertiesService: {
+      getDocumentProperties: () => documentProperties,
+      getUserProperties: () => userProperties,
+    },
     SpreadsheetApp: {},
     String,
     UrlFetchApp: {
@@ -79,7 +85,7 @@ function createHarness() {
   return {
     cache,
     context,
-    properties,
+    documentPropertyValues,
     queue(status, body, headers = {}) {
       responses.push({ status, body, headers });
     },
@@ -87,6 +93,7 @@ function createHarness() {
       responses.push(error);
     },
     requests,
+    userPropertyValues,
   };
 }
 
@@ -105,6 +112,11 @@ test("credential lifecycle never returns the stored key", () => {
   const saved = harness.context.saveApiKey("test-key-not-a-secret");
   assert.equal(saved.success, true);
   assert.equal(JSON.stringify(saved).includes("test-key-not-a-secret"), false);
+  assert.equal(
+    harness.documentPropertyValues.get("OILPRICEAPI_KEY"),
+    "test-key-not-a-secret",
+  );
+  assert.equal(harness.userPropertyValues.has("OILPRICEAPI_KEY"), false);
   assert.deepEqual(
     JSON.parse(JSON.stringify(harness.context.getApiKeyStatus())),
     { configured: true },
@@ -112,6 +124,43 @@ test("credential lifecycle never returns the stored key", () => {
 
   harness.context.deleteApiKey();
   assert.equal(harness.context.getApiKeyStatus().configured, false);
+  assert.equal(harness.documentPropertyValues.has("OILPRICEAPI_KEY"), false);
+});
+
+test("spreadsheet-scoped key survives the custom-function user identity boundary", () => {
+  const harness = createHarness();
+  configure(harness);
+  harness.context.PropertiesService.getUserProperties = () => ({
+    getProperty: () => null,
+    setProperty: () => undefined,
+    deleteProperty: () => undefined,
+  });
+  harness.queue(200, latestBody());
+
+  assert.equal(harness.context.OILPRICE_PRICE("WTI_USD"), 81.78);
+  assert.match(
+    harness.requests[0].options.headers.Authorization,
+    /^Token test-key-not-a-secret$/,
+  );
+});
+
+test("legacy user-property key remains readable until it is saved per spreadsheet", () => {
+  const harness = createHarness();
+  harness.userPropertyValues.set("OILPRICEAPI_KEY", "legacy-key");
+  harness.queue(200, latestBody());
+
+  assert.equal(harness.context.OILPRICE_PRICE("WTI_USD"), 81.78);
+  assert.equal(
+    harness.requests[0].options.headers.Authorization,
+    "Token legacy-key",
+  );
+
+  harness.context.saveApiKey("spreadsheet-key");
+  assert.equal(harness.userPropertyValues.has("OILPRICEAPI_KEY"), false);
+  assert.equal(
+    harness.documentPropertyValues.get("OILPRICEAPI_KEY"),
+    "spreadsheet-key",
+  );
 });
 
 test("OILPRICE rejects a missing key with a recovery action", () => {

--- a/test/validate_code.js
+++ b/test/validate_code.js
@@ -114,6 +114,7 @@ function validateManifest() {
   assert.deepEqual(manifest.oauthScopes, [
     "https://www.googleapis.com/auth/spreadsheets.currentonly",
     "https://www.googleapis.com/auth/script.external_request",
+    "https://www.googleapis.com/auth/script.container.ui",
   ]);
   assert.deepEqual(manifest.urlFetchWhitelist, [
     "https://api.oilpriceapi.com/",


### PR DESCRIPTION
## Outcome

Fixes `=OILPRICE_PRICE("WTI_USD")` and the other custom formulas when the sidebar user is not the spreadsheet owner.

Google Apps Script custom functions do not read the active editor user properties; they resolve the spreadsheet owner properties. The add-on now stores the API key in Apps Script document properties scoped to the current spreadsheet, never in cells or browser-side HTML.

## Release

- Apps Script immutable version: `7`
- Script ID: `1rlVWvciYu-wzqnY009I3oW-08ZPazYK1snrrMg9NNY7c5WBSkUK8W2Hb`
- versions 2-4 lack `script.container.ui`
- versions 5-6 retain the broken user-property formula behavior

## Verification

- `npm run validate`: 28 passed, 0 failed
- production formula smoke passed against the live API
- immutable version 7 matches the reviewed local Code, Sidebar, FetchDialog, and manifest
- credential value is never returned to browser code or written to spreadsheet cells