### PR TITLE
docs: record Marketplace submission in review

### DIFF
--- a/MARKETPLACE_LISTING.md
+++ b/MARKETPLACE_LISTING.md
@@ -1,13 +1,13 @@
 # Google Workspace Marketplace Listing
 
-Status: submission-ready copy for the Editor add-on. Do not claim Marketplace
-availability until Google publishes the listing.
+Status: submitted July 26, 2026 and locked in Google review. Do not claim
+Marketplace availability until Google publishes the listing.
 
 ## App details
 
 - Default language: English
 - Application name: `OilPriceAPI for Sheets`
-- Category: Business Tools
+- Category: Accounting and Finance
 - Pricing: Free of charge with paid features
 - Developer name: `OilPriceAPI`
 - Developer website: `https://www.oilpriceapi.com`
@@ -51,8 +51,7 @@ Detailed description:
 
 ## OAuth scopes and justification
 
-Use the same three scopes in the Apps Script manifest, OAuth consent screen, and
-Marketplace SDK:
+The Apps Script manifest declares these three functional scopes:
 
 | Scope | Justification |
 | --- | --- |
@@ -60,8 +59,23 @@ Marketplace SDK:
 | `https://www.googleapis.com/auth/script.external_request` | Send authenticated HTTPS GET requests to `api.oilpriceapi.com` for data explicitly requested by the user. |
 | `https://www.googleapis.com/auth/script.container.ui` | Display the add-on menu, API-key sidebar, help alerts, and data-fetch dialog inside the spreadsheet where the user runs the add-on. |
 
-The add-on does not request Drive-wide access, email, profile, or user-info
-scopes.
+The submitted OAuth/Marketplace configuration also displays Google's mandatory
+`userinfo.email` and `userinfo.profile` defaults. The add-on does not use those
+identity defaults for product behavior and does not request Drive-wide access.
+
+## Submission receipt
+
+- Google Cloud project: `oilpriceapi-sheets-addon` (`991152473434`)
+- Apps Script version: `7`
+- Integration: Google Sheets Editor add-on
+- Install modes: individual and administrator
+- Regions: all regions
+- Review state: **In review**
+- Locked-state proof: **“The draft is in review and can't be edited”**
+
+The OAuth consent screen was still in Testing at submission, and two identity
+scopes were marked unverified. Google may require production consent status and
+OAuth verification during review. Publication remains pending until approval.
 
 ## Graphic assets
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 Deployment-ready Editor add-on for source-aware OilPriceAPI formulas in Google
 Sheets.
 
-> Google Workspace Marketplace publication is pending. The source and release
-> package are ready; account-bound Apps Script, OAuth, test-deployment, and
-> Marketplace submission steps remain.
+> Google Workspace Marketplace publication is pending. The public listing was
+> submitted on July 26, 2026 and is locked in Google review. The reviewed
+> Apps Script release is version 7. Do not claim Marketplace availability
+> until Google approves and publishes the listing.
 
 Dataset access, history, freshness, and limits depend on the API key, source,
 and account entitlement. Review the

--- a/TEST_RESULTS.md
+++ b/TEST_RESULTS.md
@@ -94,7 +94,7 @@ Result on 2026-07-24:
 The smoke used the existing non-customer key from the local environment. The
 script passes the key to `curl` through standard input and never prints it.
 
-## Account-bound release gates
+## Account-bound release and submission gates
 
 Completed on 2026-07-24:
 
@@ -116,12 +116,20 @@ Production release target:
 - Apps Script editor:
   `https://script.google.com/d/1rlVWvciYu-wzqnY009I3oW-08ZPazYK1snrrMg9NNY7c5WBSkUK8W2Hb/edit`
 
-Remaining Google account/Marketplace gates:
+Completed on 2026-07-26:
 
-- link that script to the standard Google Cloud project;
-- install and smoke the Editor add-on test deployment in a clean Sheet;
-- capture at least one real 1280x800 screenshot;
-- configure OAuth and Marketplace SDK with the Script ID and version;
-- complete any required OAuth verification and submit the public listing.
+- linked the script to Google Cloud project `oilpriceapi-sheets-addon`;
+- installed and smoked the Editor add-on test deployment in a clean Sheet;
+- uploaded the reviewed 1280x800 runtime screenshot and all required graphics;
+- configured the Marketplace SDK with Apps Script version `7`;
+- submitted the public listing for review;
+- recorded the locked state: **“The draft is in review and can't be edited.”**
+
+Remaining Google-controlled gates:
+
+- complete OAuth verification if Google requests it;
+- wait for Marketplace approval and publication;
+- after approval, install from the public listing with a separate clean account
+  and repeat the customer-critical smoke before changing availability claims.
 
 See [DEPLOYMENT_GUIDE.md](DEPLOYMENT_GUIDE.md).

--- a/WEEKEND_ACTION.md
+++ b/WEEKEND_ACTION.md
@@ -1,6 +1,8 @@
-# Saturday action: submit OilPriceAPI for Sheets
+# Weekend action: submit OilPriceAPI for Sheets
 
 Target date: Saturday, July 25, 2026
+
+Completed: Sunday, July 26, 2026
 
 ## Outcome
 
@@ -26,41 +28,46 @@ linked above is the reviewed production target.
 
 ### 1. Link the standard Google Cloud project
 
-- [ ] Sign in as `karl.waldman@gmail.com`.
-- [ ] Open the Apps Script project above and select **Project Settings**.
-- [ ] Replace the default Apps Script Cloud project with the organization-owned
+- [x] Sign in with the publisher-controlled Google account.
+- [x] Open the Apps Script project above and select **Project Settings**.
+- [x] Replace the default Apps Script Cloud project with the organization-owned
       standard Google Cloud project's numeric project number.
-- [ ] Confirm the Apps Script API and Google Workspace Marketplace SDK are
+- [x] Confirm the Apps Script API and Google Workspace Marketplace SDK are
       enabled in that Cloud project.
-- [ ] Add a backup organization-controlled collaborator to the Apps Script and
+- [x] Add a backup organization-controlled collaborator to the Apps Script and
       Cloud projects.
 
 ### 2. Configure OAuth
 
-- [ ] Configure the OAuth consent screen as **External**.
-- [ ] Use app name `OilPriceAPI for Sheets`.
-- [ ] Use `support@oilpriceapi.com` for user support and developer contact.
-- [ ] Use:
+- [x] Configure the OAuth consent screen as **External**.
+- [x] Use app name `OilPriceAPI for Sheets`.
+- [x] Use an organization-controlled support and developer contact.
+- [x] Use:
       `https://www.oilpriceapi.com/privacy/google-sheets-addon`
       and
       `https://www.oilpriceapi.com/terms/google-sheets-addon`.
-- [ ] Declare exactly these scopes:
+- [x] Declare these three functional scopes:
       `https://www.googleapis.com/auth/spreadsheets.currentonly`,
       `https://www.googleapis.com/auth/script.external_request`, and
       `https://www.googleapis.com/auth/script.container.ui`.
-- [ ] Add the publisher and clean smoke-test accounts as test users while OAuth
+- [x] Accept Google's two mandatory identity defaults,
+      `userinfo.email` and `userinfo.profile`, in the submitted consent/listing
+      configuration. The Apps Script manifest still declares only the three
+      functional scopes above.
+- [x] Add the publisher and clean smoke-test accounts as test users while OAuth
       remains in Testing status.
 
-Do not add Drive-wide, email, profile, or `userinfo.email` scopes.
+Do not add Drive-wide scopes or use the Google identity defaults for product
+behavior.
 
 ### 3. Create and smoke-test the Editor add-on
 
-- [ ] Create a blank spreadsheet containing no customer data.
-- [ ] In Apps Script, select **Deploy → Test deployments → Editor add-on**.
-- [ ] Test **Latest Code** against the blank spreadsheet.
-- [ ] Open the sidebar and confirm it initially reports no stored API key.
-- [ ] Save a non-customer OilPriceAPI test key and test the connection.
-- [ ] Run:
+- [x] Create a blank spreadsheet containing no customer data.
+- [x] In Apps Script, select **Deploy → Test deployments → Editor add-on**.
+- [x] Test **Latest Code** against the blank spreadsheet.
+- [x] Open the sidebar and confirm it initially reports no stored API key.
+- [x] Save a non-customer OilPriceAPI test key and test the connection.
+- [x] Run:
 
 ```text
 =OILPRICE_PRICE("WTI_USD")
@@ -71,10 +78,10 @@ Do not add Drive-wide, email, profile, or `userinfo.email` scopes.
 =OILPRICE_GET("/v1/prices/latest","by_code=WTI_USD")
 ```
 
-- [ ] Confirm unsupported endpoints and query keys such as `api_key`, `token`,
+- [x] Confirm unsupported endpoints and query keys such as `api_key`, `token`,
       and `password` fail before a request.
-- [ ] Delete the stored key and confirm the sidebar returns to no-key state.
-- [ ] Review Apps Script Executions for exceptions, retries, unexpected 4xx/5xx
+- [x] Delete the stored key and confirm the sidebar returns to no-key state.
+- [x] Review Apps Script Executions for exceptions, retries, unexpected 4xx/5xx
       responses, or any credential/query-string leakage.
 
 ### 4. Capture submission proof
@@ -89,31 +96,55 @@ Do not add Drive-wide, email, profile, or `userinfo.email` scopes.
 
 ### 5. Configure and submit Marketplace
 
-- [ ] In Google Workspace Marketplace SDK, add an **Editor add-on** integration
+- [x] In Google Workspace Marketplace SDK, add an **Editor add-on** integration
       for Google Sheets.
-- [ ] Enter the Script ID above and immutable version `7`.
-- [ ] Enter the same three OAuth scopes.
-- [ ] Choose **Public** visibility before saving. Google treats this choice as
+- [x] Enter the Script ID above and immutable version `7`.
+- [x] Enter the three functional OAuth scopes plus Google's two mandatory
+      identity defaults.
+- [x] Choose **Public** visibility before saving. Google treats this choice as
       permanent; do not use Private as temporary staging.
-- [ ] Upload:
+- [x] Upload:
       `assets/marketplace/app-icon-32.png`,
       `assets/marketplace/app-icon-128.png`,
       `assets/marketplace/card-banner-220x140.png`,
       and the approved screenshot.
-- [ ] Paste the approved copy and links from `MARKETPLACE_LISTING.md`.
-- [ ] Submit OAuth verification if Google requests it.
-- [ ] Submit the Marketplace listing for review.
+- [x] Paste the approved copy and links from `MARKETPLACE_LISTING.md`.
+- [x] Submit the Marketplace listing for review.
+- [ ] Complete Google's OAuth verification if requested during review.
 
 ## Done when
 
-- [ ] The Marketplace console shows a submitted/review state.
-- [ ] The submission confirmation or receipt is saved.
-- [ ] The exact submitted Script ID and version are recorded as:
+- [x] The Marketplace console shows a submitted/review state.
+- [x] The locked-review confirmation is recorded below.
+- [x] The exact submitted Script ID and version are recorded as:
       `1rlVWvciYu-wzqnY009I3oW-08ZPazYK1snrrMg9NNY7c5WBSkUK8W2Hb`, version `7`.
-- [ ] No public page claims Marketplace availability before Google approves the
+- [x] No public page claims Marketplace availability before Google approves the
       listing.
 - [ ] After approval, a separate clean account installs the public listing and
       repeats the customer-critical smoke test before marketing copy changes.
+
+## Submission receipt
+
+Submitted on July 26, 2026:
+
+- listing: `OilPriceAPI for Sheets`;
+- state: **In review**;
+- console proof: **“The draft is in review and can't be edited”**, with the
+  review-cancellation control present and draft saving disabled;
+- Google Cloud project: `oilpriceapi-sheets-addon` (`991152473434`);
+- Apps Script version: `7`;
+- integration: Google Sheets Editor add-on;
+- installation: individual and administrator install;
+- regions: all regions.
+
+Review caveats:
+
+- the OAuth consent screen was still in Testing when submitted; Google may
+  require it to move to In production;
+- two submitted identity scopes are marked unverified, so Google may route the
+  listing through OAuth verification;
+- neither caveat blocked submission, and the review must not be canceled merely
+  to change repository copy.
 
 Versions `2`, `3`, and `4` do not include the required
 `script.container.ui` scope. Versions `5` and `6` still read formula

--- a/docs/index.html
+++ b/docs/index.html
@@ -69,7 +69,7 @@
   <body>
     <header>
       <div class="inner">
-        <div class="status">MARKETPLACE SUBMISSION CANDIDATE</div>
+        <div class="status">MARKETPLACE SUBMITTED — IN REVIEW</div>
         <h1>OilPriceAPI for Google Sheets</h1>
         <p>
           Source-aware energy data formulas with price, unit, timestamp,
@@ -81,8 +81,9 @@
       <h2>Publication status</h2>
       <p>
         Google Workspace Marketplace publication is pending. The Editor add-on
-        runtime and deployment package are ready for account-bound Apps Script,
-        OAuth, test-deployment, and Marketplace submission steps.
+        was submitted on July 26, 2026 and the draft is locked in Google
+        review. Do not claim public availability until Google approves and
+        publishes the listing.
       </p>
 
       <h2>First formula</h2>

--- a/test/public-claims.test.js
+++ b/test/public-claims.test.js
@@ -22,6 +22,9 @@ test("public surfaces identify Marketplace status and canonical facts", () => {
     fs.readFileSync(path.join(ROOT, file), "utf8"),
   ).join("\n");
   assert.match(text, /Google Workspace Marketplace publication (?:is )?pending/i);
+  assert.match(text, /submitted (?:on )?July 26, 2026/i);
+  assert.match(text, /locked in Google review/i);
+  assert.doesNotMatch(text, /Marketplace submission steps remain/i);
   assert.match(text, /https:\/\/api\.oilpriceapi\.com\/product-facts\.json/);
 });
 


### PR DESCRIPTION
## Outcome

Records the completed Google Workspace Marketplace submission without claiming public availability before approval.

## Submission receipt

- listing is locked **In review**
- console states: “The draft is in review and can't be edited”
- Google Cloud project and immutable Apps Script version 7 are recorded
- Editor add-on, individual/admin installation, required assets, and all-regions configuration are recorded
- runtime manifest's three functional scopes are distinguished from Google's two mandatory identity defaults
- OAuth Testing/unverified-scope review caveats are explicit

## Verification

- `npm run validate` — 28 tests pass
- deployment package verification passes
- Marketplace asset verification passes
- secret scan passes
- public claims continue to say publication pending

Docs/GitHub Pages deployment is already authorized. This does not create a new Apps Script version, change the locked Marketplace submission, or claim that Google has approved the listing.

Closes #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Marketplace, README, and workflow documentation to reflect submission on July 26, 2026, and the listing’s locked Google review status.
  * Clarified publication status, OAuth scope disclosures, installation details, review requirements, and submission records.
  * Expanded smoke-test and release checklists with additional validation steps.

* **Website**
  * Updated the landing page to show “MARKETPLACE SUBMITTED — IN REVIEW.”
  * Added guidance not to claim public availability until approval and publication.

* **Tests**
  * Added checks ensuring public messaging reflects the submission date and review status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->