### PR TITLE
test: cover Sheets Data Connector flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ npm run validate
 
 The validation suite covers formula parity, credential lifecycle, negative
 auth/entitlement/quota paths, response-shape drift, stale cache, source
-metadata, endpoint/query allowlisting, deployment packaging, Marketplace asset
-dimensions, public claims, and secret scanning.
+metadata, Data Connector filtering and sheet output, endpoint/query
+allowlisting, deployment packaging, Marketplace asset dimensions, public
+claims, and secret scanning.
 
 For a production API smoke:
 
@@ -88,7 +89,18 @@ For a production API smoke:
 OILPRICEAPI_KEY="your non-customer test key" npm run test:live
 ```
 
-The live-smoke script does not print the key.
+The standard smoke skips the account-gated Data Connector checks. Run those
+with an entitled non-customer account and known valid filters:
+
+```bash
+OILPRICEAPI_KEY="your non-customer test key" \
+OILPRICEAPI_DATA_CONNECTOR_SMOKE=1 \
+OILPRICEAPI_DATA_CONNECTOR_PORT="SINGAPORE" \
+OILPRICEAPI_DATA_CONNECTOR_FUEL="VLSFO" \
+npm run test:live
+```
+
+The live-smoke script does not print the key or filter values.
 
 ## Deploy
 

--- a/TEST_RESULTS.md
+++ b/TEST_RESULTS.md
@@ -1,6 +1,6 @@
 # Verification Results
 
-Verification date: 2026-07-25
+Verification date: 2026-07-26
 
 ## Apps Script scope correction
 
@@ -30,7 +30,7 @@ npm run validate
 
 Result:
 
-- 28 runtime/public-claims tests passed, 0 failed.
+- 39 runtime/public-claims tests passed, 0 failed.
 - Apps Script syntax, required functions, UI bindings, scopes, and fetch
   allowlist are valid.
 - The deployment package exposes only `Code.gs`, `Sidebar.html`,
@@ -55,7 +55,11 @@ Covered behavior includes:
 - flat price, keyed price, diesel, and nested futures table rendering;
 - source timestamp, unit, freshness, and diagnostic preservation;
 - fresh/stale cache envelopes, history, batch limit, conversion behavior, and
-  no fabricated exchange-rate fallbacks or account limits.
+  no fabricated exchange-rate fallbacks or account limits;
+- Data Connector response validation, filter normalization and encoding,
+  account-lock/rate-limit/timeout recovery, both bunker formulas, the
+  nine-column green-header sheet writer, success alert, and empty-data
+  recovery.
 
 ## Dependency audit
 
@@ -94,6 +98,21 @@ Result on 2026-07-24:
 The smoke used the existing non-customer key from the local environment. The
 script passes the key to `curl` through standard input and never prints it.
 
+The Data Connector portion is intentionally opt-in because it requires an
+entitled account and known valid port/fuel filters:
+
+```bash
+OILPRICEAPI_KEY="non-customer entitled test key" \
+OILPRICEAPI_DATA_CONNECTOR_SMOKE=1 \
+OILPRICEAPI_DATA_CONNECTOR_PORT="known valid port" \
+OILPRICEAPI_DATA_CONNECTOR_FUEL="known valid fuel" \
+npm run test:live
+```
+
+When enabled, the smoke exercises the menu fetch, validates the nine-column
+sheet and green header, and runs both bunker custom functions against the
+production API. This entitled live smoke has not yet been run.
+
 ## Account-bound release and submission gates
 
 Completed on 2026-07-24:
@@ -131,5 +150,11 @@ Remaining Google-controlled gates:
 - wait for Marketplace approval and publication;
 - after approval, install from the public listing with a separate clean account
   and repeat the customer-critical smoke before changing availability claims.
+
+Remaining Data Connector acceptance gate:
+
+- run the opt-in production smoke with a Data Connector-enabled non-customer
+  account, then repeat the menu item and both formulas inside the submitted
+  Apps Script version in a clean spreadsheet.
 
 See [DEPLOYMENT_GUIDE.md](DEPLOYMENT_GUIDE.md).

--- a/test/live-smoke.js
+++ b/test/live-smoke.js
@@ -10,6 +10,10 @@ const apiKey = process.env.OILPRICEAPI_KEY;
 if (!apiKey) {
   throw new Error("Set OILPRICEAPI_KEY before running npm run test:live.");
 }
+const dataConnectorSmoke =
+  process.env.OILPRICEAPI_DATA_CONNECTOR_SMOKE === "1";
+const dataConnectorPort = process.env.OILPRICEAPI_DATA_CONNECTOR_PORT;
+const dataConnectorFuel = process.env.OILPRICEAPI_DATA_CONNECTOR_FUEL;
 
 function curlConfigValue(value) {
   return String(value).replaceAll("\\", "\\\\").replaceAll('"', '\\"');
@@ -45,6 +49,37 @@ function fetchWithCurl(url, options) {
 }
 
 const cache = new Map();
+const connectorAlerts = [];
+const connectorRanges = [];
+const connectorSheet = {
+  activate: () => undefined,
+  autoResizeColumns: () => undefined,
+  clear: () => undefined,
+  getRange(row, column, rowCount, columnCount) {
+    assert.ok(rowCount > 0 && columnCount > 0);
+    const state = { row, column, rowCount, columnCount };
+    const range = {
+      setBackground(value) {
+        state.background = value;
+        return range;
+      },
+      setFontWeight(value) {
+        state.fontWeight = value;
+        return range;
+      },
+      setNumberFormat(value) {
+        state.numberFormat = value;
+        return range;
+      },
+      setValues(values) {
+        state.values = values;
+        return range;
+      },
+    };
+    connectorRanges.push(state);
+    return range;
+  },
+};
 const code = fs.readFileSync(path.join(__dirname, "..", "Code.gs"), "utf8");
 const context = {
   CacheService: {
@@ -69,6 +104,15 @@ const context = {
       getProperty: () => null,
       setProperty: () => undefined,
       deleteProperty: () => undefined,
+    }),
+  },
+  SpreadsheetApp: {
+    getActiveSpreadsheet: () => ({
+      getSheetByName: () => connectorSheet,
+      insertSheet: () => connectorSheet,
+    }),
+    getUi: () => ({
+      alert: (message) => connectorAlerts.push(message),
     }),
   },
   String,
@@ -105,6 +149,63 @@ const history = context.OILPRICE_HISTORY("WTI_USD", 1);
 assert.ok(Array.isArray(history) && history.length > 0);
 assert.ok(Number.isFinite(new Date(history[0][0]).getTime()));
 assert.ok(Number.isFinite(history[0][1]));
+
+if (dataConnectorSmoke) {
+  if (!dataConnectorPort || !dataConnectorFuel) {
+    throw new Error(
+      "Set OILPRICEAPI_DATA_CONNECTOR_PORT and OILPRICEAPI_DATA_CONNECTOR_FUEL when OILPRICEAPI_DATA_CONNECTOR_SMOKE=1.",
+    );
+  }
+
+  context.fetchDataConnectorPrices();
+  assert.equal(connectorAlerts.length, 1);
+  assert.match(connectorAlerts[0], /^Fetched \d+ source-timestamped bunker price records\.$/);
+  const headerRange = connectorRanges.find(
+    (range) => range.row === 1 && range.column === 1 && range.values,
+  );
+  const headerStyle = connectorRanges.find(
+    (range) => range.row === 1 && range.column === 1 && range.fontWeight,
+  );
+  const dataRange = connectorRanges.find(
+    (range) => range.row === 2 && range.column === 1 && range.values,
+  );
+  assert.equal(headerRange.columnCount, 9);
+  assert.equal(headerStyle.fontWeight, "bold");
+  assert.equal(headerStyle.background, "#e8f5e9");
+  assert.ok(dataRange.rowCount > 0);
+  assert.ok(dataRange.values.every((row) => row.length === 9));
+
+  const bunkerPrice = context.BUNKER_PRICE(
+    dataConnectorPort,
+    dataConnectorFuel,
+  );
+  assert.ok(Number.isFinite(bunkerPrice) && bunkerPrice > 0);
+
+  const bunkerTable = context.BUNKER_PORT_PRICES(dataConnectorPort);
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(bunkerTable[0])),
+    ["Fuel Type", "Price", "Currency", "Unit", "Source Timestamp"],
+  );
+  assert.ok(bunkerTable.length > 1);
+  assert.ok(
+    bunkerTable.slice(1).every(
+      (row) =>
+        row.length === 5 &&
+        Number.isFinite(row[1]) &&
+        typeof row[2] === "string" &&
+        typeof row[3] === "string" &&
+        Number.isFinite(new Date(row[4]).getTime()),
+    ),
+  );
+
+  console.log(
+    `Production Data Connector smoke passed: menu_rows=${dataRange.rowCount}, formula_price=${bunkerPrice}, port_rows=${bunkerTable.length - 1}`,
+  );
+} else {
+  console.log(
+    "Production Data Connector smoke skipped; set OILPRICEAPI_DATA_CONNECTOR_SMOKE=1 with port and fuel inputs to run the entitled-account checks.",
+  );
+}
 
 console.log(
   `Production formula smoke passed: latest=${price}, unit=${unit}, info_source_timestamp=${infoMap.source_timestamp}, history_records=${history.length}`,

--- a/test/runtime.test.js
+++ b/test/runtime.test.js
@@ -25,6 +25,24 @@ function historyBody(records) {
   return JSON.stringify({ status: "success", data: { prices: records } });
 }
 
+function bunkerBody(records) {
+  return JSON.stringify({ status: "success", data: { prices: records } });
+}
+
+function bunkerRecord(overrides = {}) {
+  return {
+    port: "SINGAPORE",
+    fuel_type: "VLSFO",
+    price: 612.5,
+    currency: "USD",
+    unit: "metric_ton",
+    region: "Asia",
+    source: "fixture_provider",
+    as_of: "2026-07-25T09:30:00.000Z",
+    ...overrides,
+  };
+}
+
 function createHarness() {
   const documentPropertyValues = new Map();
   const userPropertyValues = new Map();
@@ -95,6 +113,77 @@ function createHarness() {
     requests,
     userPropertyValues,
   };
+}
+
+function attachSpreadsheet(harness, existingSheet = true) {
+  const calls = [];
+  const alerts = [];
+  const ranges = [];
+
+  function makeRange(row, column, rowCount, columnCount) {
+    const state = { row, column, rowCount, columnCount };
+    const range = {
+      setBackground(value) {
+        state.background = value;
+        return range;
+      },
+      setFontWeight(value) {
+        state.fontWeight = value;
+        return range;
+      },
+      setNumberFormat(value) {
+        state.numberFormat = value;
+        return range;
+      },
+      setValues(value) {
+        state.values = JSON.parse(JSON.stringify(value));
+        return range;
+      },
+    };
+    ranges.push(state);
+    return range;
+  }
+
+  const sheet = {
+    activate() {
+      calls.push(["activate"]);
+    },
+    autoResizeColumns(start, count) {
+      calls.push(["autoResizeColumns", start, count]);
+    },
+    clear() {
+      calls.push(["clear"]);
+    },
+    getRange(row, column, rowCount, columnCount) {
+      calls.push(["getRange", row, column, rowCount, columnCount]);
+      if (rowCount < 1 || columnCount < 1) {
+        throw new Error("Spreadsheet ranges must contain at least one cell.");
+      }
+      return makeRange(row, column, rowCount, columnCount);
+    },
+  };
+  let availableSheet = existingSheet ? sheet : null;
+  const spreadsheet = {
+    getSheetByName(name) {
+      calls.push(["getSheetByName", name]);
+      return availableSheet;
+    },
+    insertSheet(name) {
+      calls.push(["insertSheet", name]);
+      availableSheet = sheet;
+      return sheet;
+    },
+  };
+  harness.context.SpreadsheetApp = {
+    getActiveSpreadsheet: () => spreadsheet,
+    getUi: () => ({
+      alert(message) {
+        alerts.push(message);
+      },
+    }),
+  };
+
+  return { alerts, calls, ranges, sheet, spreadsheet };
 }
 
 function configure(harness) {
@@ -578,6 +667,224 @@ test("historical formula retains API timestamps and rejects missing timestamps",
   assert.throws(
     () => invalid.context.OILPRICE_HISTORY("WTI_USD", 1),
     /timestamp/i,
+  );
+});
+
+test("bunker records preserve the complete source contract", () => {
+  const harness = createHarness();
+  configure(harness);
+  harness.queue(200, bunkerBody([bunkerRecord()]));
+
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(harness.context.fetchBunkerRecords_(""))),
+    [
+      {
+        port: "SINGAPORE",
+        fuelType: "VLSFO",
+        price: 612.5,
+        currency: "USD",
+        unit: "metric_ton",
+        region: "Asia",
+        source: "fixture_provider",
+        timestamp: "2026-07-25T09:30:00.000Z",
+      },
+    ],
+  );
+  assert.match(harness.requests[0].url, /\/v1\/prices\/data-connector$/);
+});
+
+test("bunker records reject empty, malformed, and incomplete successful responses", () => {
+  for (const [body, pattern] of [
+    [bunkerBody([]), /no usable bunker price/i],
+    [JSON.stringify({ status: "success", data: { prices: [null] } }), /no usable bunker price/i],
+    [bunkerBody([bunkerRecord({ price: "not-a-number" })]), /finite price/i],
+    [bunkerBody([bunkerRecord({ port: "" })]), /missing port/i],
+    [bunkerBody([bunkerRecord({ fuel_type: "" })]), /missing fuel type/i],
+    [bunkerBody([bunkerRecord({ currency: "" })]), /missing currency/i],
+    [bunkerBody([bunkerRecord({ unit: "" })]), /missing unit/i],
+    [bunkerBody([bunkerRecord({ as_of: "not-a-date" })]), /source timestamp/i],
+  ]) {
+    const harness = createHarness();
+    configure(harness);
+    harness.queue(200, body);
+    assert.throws(() => harness.context.fetchBunkerRecords_(""), pattern);
+  }
+});
+
+for (const [status, pattern] of [
+  [401, /invalid or revoked API key/i],
+  [402, /cannot access the requested dataset/i],
+  [403, /cannot access the requested dataset/i],
+  [429, /rate or quota limit/i],
+]) {
+  test(`BUNKER_PRICE maps HTTP ${status} to actionable recovery`, () => {
+    const harness = createHarness();
+    configure(harness);
+    harness.queue(status, JSON.stringify({ error: "fixture" }));
+    assert.throws(
+      () => harness.context.BUNKER_PRICE("SINGAPORE", "VLSFO"),
+      pattern,
+    );
+  });
+}
+
+test("BUNKER_PRICE maps Apps Script fetch failures to timeout recovery", () => {
+  const harness = createHarness();
+  configure(harness);
+  harness.queueError(new Error("Socket timeout"));
+  assert.throws(
+    () => harness.context.BUNKER_PRICE("SINGAPORE", "VLSFO"),
+    /timed out/i,
+  );
+});
+
+test("bunker formulas normalize and encode filters and return source-aware values", () => {
+  const priceHarness = createHarness();
+  configure(priceHarness);
+  priceHarness.queue(
+    200,
+    bunkerBody([bunkerRecord({ port: "NEW-YORK:US", fuel_type: "VLSFO_0-5" })]),
+  );
+  assert.equal(
+    priceHarness.context.BUNKER_PRICE("new-york:us", "vlsfo_0-5"),
+    612.5,
+  );
+  assert.match(
+    priceHarness.requests[0].url,
+    /\?port=NEW-YORK%3AUS&fuel_type=VLSFO_0-5$/,
+  );
+
+  const tableHarness = createHarness();
+  configure(tableHarness);
+  tableHarness.queue(
+    200,
+    bunkerBody([
+      bunkerRecord(),
+      bunkerRecord({
+        fuel_type: "MGO",
+        price: "785.20",
+        unit: "tonne",
+        as_of: "2026-07-25T10:00:00.000Z",
+      }),
+    ]),
+  );
+  assert.deepEqual(
+    JSON.parse(
+      JSON.stringify(tableHarness.context.BUNKER_PORT_PRICES("singapore")),
+    ),
+    [
+      ["Fuel Type", "Price", "Currency", "Unit", "Source Timestamp"],
+      ["VLSFO", 612.5, "USD", "metric_ton", "2026-07-25T09:30:00.000Z"],
+      ["MGO", 785.2, "USD", "tonne", "2026-07-25T10:00:00.000Z"],
+    ],
+  );
+  assert.match(tableHarness.requests[0].url, /\?port=SINGAPORE$/);
+});
+
+test("bunker inputs reject unsupported filter characters before fetch", () => {
+  const harness = createHarness();
+  configure(harness);
+  assert.throws(
+    () => harness.context.BUNKER_PRICE("Singapore & Johor", "VLSFO"),
+    /unsupported characters/i,
+  );
+  assert.equal(harness.requests.length, 0);
+});
+
+test("Data Connector sheet writer creates the nine-column source-aware table", () => {
+  const harness = createHarness();
+  const spreadsheet = attachSpreadsheet(harness, false);
+  const records = [
+    {
+      port: "SINGAPORE",
+      fuelType: "VLSFO",
+      price: 612.5,
+      currency: "USD",
+      unit: "metric_ton",
+      region: "Asia",
+      source: "fixture_provider",
+      timestamp: "2026-07-25T09:30:00.000Z",
+    },
+  ];
+
+  harness.context.writeToDataConnectorSheet(records);
+
+  assert.deepEqual(spreadsheet.calls.slice(0, 3), [
+    ["getSheetByName", "Bunker Prices"],
+    ["insertSheet", "Bunker Prices"],
+    ["clear"],
+  ]);
+  const header = spreadsheet.ranges.find(
+    (range) => range.row === 1 && range.column === 1,
+  );
+  assert.deepEqual(header.values, [
+    [
+      "Port",
+      "Fuel Type",
+      "Price",
+      "Currency",
+      "Unit",
+      "Region",
+      "Source",
+      "Source Timestamp",
+      "Retrieved At",
+    ],
+  ]);
+  const headerStyle = spreadsheet.ranges.find(
+    (range) =>
+      range.row === 1 &&
+      range.column === 1 &&
+      range.fontWeight === "bold",
+  );
+  assert.equal(headerStyle.background, "#e8f5e9");
+
+  const rows = spreadsheet.ranges.find(
+    (range) => range.row === 2 && range.column === 1,
+  );
+  assert.equal(rows.rowCount, 1);
+  assert.equal(rows.columnCount, 9);
+  assert.deepEqual(rows.values[0].slice(0, 8), [
+    "SINGAPORE",
+    "VLSFO",
+    612.5,
+    "USD",
+    "metric_ton",
+    "Asia",
+    "fixture_provider",
+    "2026-07-25T09:30:00.000Z",
+  ]);
+  assert.ok(Number.isFinite(new Date(rows.values[0][8]).getTime()));
+
+  const priceRange = spreadsheet.ranges.find(
+    (range) => range.row === 2 && range.column === 3,
+  );
+  assert.equal(priceRange.numberFormat, "#,##0.00");
+  assert.deepEqual(spreadsheet.calls.slice(-2), [
+    ["autoResizeColumns", 1, 9],
+    ["activate"],
+  ]);
+});
+
+test("Data Connector menu flow alerts on success and recovers from empty data", () => {
+  const success = createHarness();
+  configure(success);
+  const successSpreadsheet = attachSpreadsheet(success);
+  success.queue(200, bunkerBody([bunkerRecord()]));
+  success.context.fetchDataConnectorPrices();
+  assert.deepEqual(successSpreadsheet.alerts, [
+    "Fetched 1 source-timestamped bunker price records.",
+  ]);
+
+  const empty = createHarness();
+  configure(empty);
+  const emptySpreadsheet = attachSpreadsheet(empty, false);
+  empty.queue(200, bunkerBody([]));
+  empty.context.fetchDataConnectorPrices();
+  assert.equal(emptySpreadsheet.alerts.length, 1);
+  assert.match(emptySpreadsheet.alerts[0], /no usable bunker price/i);
+  assert.equal(
+    emptySpreadsheet.calls.some((call) => call[0] === "insertSheet"),
+    false,
   );
 });
 


### PR DESCRIPTION
## Summary
- add runtime fixtures for bunker response validation, filters, entitlement and recovery paths
- exercise both bunker formulas plus the nine-column green-header sheet writer and menu flow
- add an opt-in entitled-account production smoke without changing Code.gs or the locked Apps Script version 7

## Verification
- npm run validate
- node --check test/live-smoke.js
- git diff --check

## Release safety
This PR changes tests and documentation only. It does not push Apps Script, create a version, alter the Marketplace submission, or trigger a frontend/backend deployment.

Related: #1