### PR TITLE
Fix Marketplace trademark attribution rejection

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -132,7 +132,7 @@ function showSidebar() {
 function showAbout() {
   const ui = SpreadsheetApp.getUi();
   ui.alert(
-    'OilPriceAPI for Google Sheets',
+    'OilPriceAPI for Google Sheets™',
     `Version ${ADDON_VERSION}\n\n` +
       'Source-timestamped energy price data. Dataset access and freshness vary.\n\n' +
       'Google Workspace Marketplace publication is pending.\n\n' +

--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -1,4 +1,4 @@
-# Deploy OilPriceAPI for Google Sheets
+# Deploy OilPriceAPI for Google Sheets™
 
 This is the production operator runbook for the Google Sheets Editor add-on.
 Code packaging is automated; Google account ownership, Cloud/OAuth settings,
@@ -9,7 +9,7 @@ test installation, screenshots, and submission require the publisher account.
 - Runtime version: `1.2.0`
 - Production Apps Script ID:
   `1rlVWvciYu-wzqnY009I3oW-08ZPazYK1snrrMg9NNY7c5WBSkUK8W2Hb`
-- Current immutable Apps Script version: `7`
+- Current immutable Apps Script version: `9`
 - GitHub production release workflow:
   `https://github.com/OilpriceAPI/google-sheets-addin/actions/workflows/apps-script-release.yml`
 - Marketplace status: publication pending
@@ -27,8 +27,8 @@ project cannot be used for publication.
 
 Recommended app identity:
 
-- OAuth app name: `OilPriceAPI for Sheets`
-- Marketplace app name: `OilPriceAPI for Sheets`
+- OAuth app name: `OilPriceAPI for Google Sheets™`
+- Marketplace app name: `OilPriceAPI for Google Sheets™`
 - User support email: `support@oilpriceapi.com`
 - Developer contact: `support@oilpriceapi.com`
 - App domain: `oilpriceapi.com`
@@ -42,7 +42,7 @@ Add at least one backup collaborator to the Apps Script and Cloud projects.
 ## 2. Create the standalone Apps Script project
 
 1. Open `https://script.google.com` with the publisher account.
-2. Create a **standalone** project named `OilPriceAPI for Sheets`.
+2. Create a **standalone** project named `OilPriceAPI for Google Sheets™`.
 3. Open Project Settings and copy its Script ID.
 4. Under Google Cloud Platform Project, switch from the default project to the
    standard Cloud project's numeric project number.
@@ -99,7 +99,9 @@ https://www.googleapis.com/auth/script.container.ui
 ```
 
 The manifest, OAuth consent screen, and Marketplace SDK scope lists must match.
-Do not add Drive-wide, email, profile, or `userinfo.email` scopes.
+Google adds the default `userinfo.email` and `userinfo.profile` identity scopes
+to the displayed OAuth configuration; preserve those defaults. Do not add
+Drive-wide access or additional functional scopes.
 
 If Google requires OAuth verification, submit the requested scope
 justifications and a demo video showing installation, authorization, API-key
@@ -175,7 +177,7 @@ screenshots until they have been reviewed for secrets and customer data.
 After the smoke passes against the exact pushed source:
 
 ```bash
-npm run deploy:version -- "OilPriceAPI for Sheets 1.2.0"
+npm run deploy:version -- "OilPriceAPI for Google Sheets 1.2.0"
 npm run deploy:list
 ```
 

--- a/MARKETPLACE_LISTING.md
+++ b/MARKETPLACE_LISTING.md
@@ -1,12 +1,13 @@
 # Google Workspace Marketplace Listing
 
-Status: submitted July 26, 2026 and locked in Google review. Do not claim
-Marketplace availability until Google publishes the listing.
+Status: rejected July 27, 2026 pending trademark attribution and OAuth
+verification remediation. Do not claim Marketplace availability until Google
+approves and publishes the listing.
 
 ## App details
 
 - Default language: English
-- Application name: `OilPriceAPI for Sheets`
+- Application name: `OilPriceAPI for Google Sheets™`
 - Category: Accounting and Finance
 - Pricing: Free of charge with paid features
 - Developer name: `OilPriceAPI`
@@ -18,10 +19,10 @@ Short description:
 
 Detailed description:
 
-> OilPriceAPI for Sheets adds source-aware energy data formulas to Google
-> Sheets. Configure an OilPriceAPI key once in the sidebar, then request the
-> latest available value, its currency and unit, source timestamp, freshness
-> state, or an allowlisted API table.
+> OilPriceAPI for Google Sheets™ adds source-aware energy data formulas to
+> Google Sheets™. Configure an OilPriceAPI key once in the sidebar, then
+> request the latest available value, its currency and unit, source timestamp,
+> freshness state, or an allowlisted API table.
 >
 > Core formulas include OILPRICE_PRICE, OILPRICE_INFO, OILPRICE_STATUS,
 > OILPRICE_UNIT, OILPRICE_CODES, and OILPRICE_GET. Existing OILPRICE,
@@ -39,6 +40,8 @@ Detailed description:
 > editors can cause installed add-on formulas to make requests using the
 > configured key. Generic GET requests are restricted to a reviewed endpoint
 > catalog and reject credential-shaped query parameters.
+>
+> Google Sheets™ is a trademark of Google LLC.
 
 ## Support links
 
@@ -66,16 +69,18 @@ identity defaults for product behavior and does not request Drive-wide access.
 ## Submission receipt
 
 - Google Cloud project: `oilpriceapi-sheets-addon` (`991152473434`)
-- Apps Script version: `7`
+- Apps Script version: `9`
 - Integration: Google Sheets Editor add-on
 - Install modes: individual and administrator
 - Regions: all regions
-- Review state: **In review**
-- Locked-state proof: **“The draft is in review and can't be edited”**
+- Review state: **Rejected — remediation in progress**
+- Rejection email received: **July 27, 2026**
 
-The OAuth consent screen was still in Testing at submission, and two identity
-scopes were marked unverified. Google may require production consent status and
-OAuth verification during review. Publication remains pending until approval.
+Google requires the OAuth consent screen to be **In production** and the three
+functional scopes above to match exactly in the Apps Script manifest,
+Marketplace SDK App Configuration, and OAuth consent screen. Google's default
+`userinfo.email` and `userinfo.profile` scopes remain in place. Do not resubmit
+until OAuth approval is complete.
 
 ## Graphic assets
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# OilPriceAPI for Google Sheets
+# OilPriceAPI for Google Sheets™
 
 Deployment-ready Editor add-on for source-aware OilPriceAPI formulas in Google
-Sheets.
+Sheets™.
 
 > Google Workspace Marketplace publication is pending. The public listing was
-> submitted on July 26, 2026 and is locked in Google review. The reviewed
-> Apps Script release is version 7. Do not claim Marketplace availability
-> until Google approves and publishes the listing.
+> submitted on July 26, 2026 and rejected on July 27 pending trademark
+> attribution and OAuth verification remediation. Do not claim Marketplace
+> availability until Google approves and publishes the listing.
 
 Dataset access, history, freshness, and limits depend on the API key, source,
 and account entitlement. Review the
@@ -113,7 +113,7 @@ npm run clasp:login
 read -r "OPA_SCRIPT_ID?Apps Script ID: "
 npm run clasp:configure -- "$OPA_SCRIPT_ID"
 npm run deploy:push
-npm run deploy:version -- "OilPriceAPI for Sheets 1.2.0"
+npm run deploy:version -- "OilPriceAPI for Google Sheets 1.2.0"
 ```
 
 Editor add-on publication uses the Apps Script **script ID and version

--- a/Sidebar.html
+++ b/Sidebar.html
@@ -164,7 +164,7 @@
   </head>
   <body>
     <h1>OilPriceAPI</h1>
-    <div class="subtle">Source-aware formulas for Google Sheets</div>
+    <div class="subtle">Source-aware formulas for Google Sheets™</div>
     <div class="notice">
       Google Workspace Marketplace publication is pending.
       Dataset access and freshness depend on the API key and source.

--- a/assets/marketplace/app-icon.svg
+++ b/assets/marketplace/app-icon.svg
@@ -1,5 +1,5 @@
 <svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
-  <title id="title">OilPriceAPI for Sheets</title>
+  <title id="title">OilPriceAPI for Google Sheets™</title>
   <rect width="128" height="128" rx="22" fill="#0b57d0"/>
   <path d="M64 15S47 38 47 54c0 13 8 23 17 23s17-10 17-23C81 38 64 15 64 15Z" fill="#fff"/>
   <path d="M28 111h72" stroke="#9ec3ff" stroke-width="5" stroke-linecap="round"/>

--- a/assets/marketplace/card-banner.svg
+++ b/assets/marketplace/card-banner.svg
@@ -1,5 +1,5 @@
 <svg width="220" height="140" viewBox="0 0 220 140" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title description">
-  <title id="title">OilPriceAPI for Sheets</title>
+  <title id="title">OilPriceAPI for Google Sheets™</title>
   <desc id="description">Source-aware energy data formulas for spreadsheets.</desc>
   <defs>
     <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>OilPriceAPI for Google Sheets</title>
+    <title>OilPriceAPI for Google Sheets™</title>
     <meta
       name="description"
-      content="Source-aware OilPriceAPI formulas for Google Sheets. Marketplace publication pending."
+      content="Source-aware OilPriceAPI formulas for Google Sheets™. Marketplace publication pending."
     />
-    <meta property="og:title" content="OilPriceAPI for Google Sheets" />
+    <meta property="og:title" content="OilPriceAPI for Google Sheets™" />
     <meta
       property="og:description"
       content="Deployment-ready Editor add-on with price, source, timestamp, unit, freshness, catalog, and allowlisted API formulas."
@@ -69,8 +69,8 @@
   <body>
     <header>
       <div class="inner">
-        <div class="status">MARKETPLACE SUBMITTED — IN REVIEW</div>
-        <h1>OilPriceAPI for Google Sheets</h1>
+        <div class="status">MARKETPLACE REJECTED — REMEDIATION IN PROGRESS</div>
+        <h1>OilPriceAPI for Google Sheets™</h1>
         <p>
           Source-aware energy data formulas with price, unit, timestamp,
           freshness, catalog, and allowlisted API tables.
@@ -81,9 +81,9 @@
       <h2>Publication status</h2>
       <p>
         Google Workspace Marketplace publication is pending. The Editor add-on
-        was submitted on July 26, 2026 and the draft is locked in Google
-        review. Do not claim public availability until Google approves and
-        publishes the listing.
+        was submitted on July 26, 2026 and rejected on July 27 pending
+        trademark attribution and OAuth verification remediation. Do not claim
+        public availability until Google approves and publishes the listing.
       </p>
 
       <h2>First formula</h2>

--- a/test/public-claims.test.js
+++ b/test/public-claims.test.js
@@ -23,9 +23,20 @@ test("public surfaces identify Marketplace status and canonical facts", () => {
   ).join("\n");
   assert.match(text, /Google Workspace Marketplace publication (?:is )?pending/i);
   assert.match(text, /submitted (?:on )?July 26, 2026/i);
-  assert.match(text, /locked in Google review/i);
+  assert.match(text, /rejected (?:on )?July 27/i);
+  assert.match(text, /trademark attribution and OAuth verification remediation/i);
   assert.doesNotMatch(text, /Marketplace submission steps remain/i);
   assert.match(text, /https:\/\/api\.oilpriceapi\.com\/product-facts\.json/);
+});
+
+test("Marketplace listing gives Google Sheets trademark attribution", () => {
+  const listing = fs.readFileSync(
+    path.join(ROOT, "MARKETPLACE_LISTING.md"),
+    "utf8",
+  );
+  assert.match(listing, /Application name: `OilPriceAPI for Google Sheets™`/);
+  assert.match(listing, /Google Sheets™ is a trademark of Google LLC\./);
+  assert.doesNotMatch(listing, /OilPriceAPI for Sheets(?!™)/);
 });
 
 test("public surfaces contain no unsupported mutable claims", () => {


### PR DESCRIPTION
## Summary
- update Marketplace and OAuth app naming to OilPriceAPI for Google Sheets™
- add the required Google LLC trademark attribution
- record the July 27 rejection and OAuth remediation requirements
- update the add-on UI and release docs to Apps Script version 9
- add a regression test for the Marketplace listing attribution

## Verification
- npm run validate
- 40 tests passed
- deployment package, Marketplace assets, and secret scan passed
- pushed Apps Script immutable version 9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated product branding to “OilPriceAPI for Google Sheets™” across the add-on interface and public materials.
  * Updated Marketplace and publication status messaging to reflect rejection and ongoing trademark attribution and OAuth verification remediation.
  * Clarified OAuth scope requirements and deployment guidance.
* **Tests**
  * Added checks to verify trademark attribution and accurate Marketplace status messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->